### PR TITLE
1.20 Update, Translation Capabilities

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,5 +1,5 @@
 plugins {
-	id 'fabric-loom' version '0.12-SNAPSHOT'
+	id 'fabric-loom' version '1.4-SNAPSHOT'
 	id 'maven-publish'
 }
 
@@ -13,12 +13,8 @@ group = project.maven_group
 repositories {
 	maven { url 'https://oss.sonatype.org/content/repositories/snapshots' }
 	maven {
-		name = 'Ladysnake Mods'
-		url = 'https://ladysnake.jfrog.io/artifactory/mods'
-		content {
-			includeGroup 'io.github.ladysnake'
-			includeGroupByRegex 'io\\.github\\.onyxstudios.*'
-		}
+		name = "Ladysnake Libs"
+		url = uri("https://ladysnake.jfrog.io/artifactory/mods")
 	}
 }
 
@@ -31,10 +27,10 @@ dependencies {
 	// Fabric API. This is technically optional, but you probably want it anyway.
 	modImplementation "net.fabricmc.fabric-api:fabric-api:${project.fabric_version}"
 
-	modImplementation "me.lucko:fabric-permissions-api:${project.fpa_version}"
+	include(modImplementation "me.lucko:fabric-permissions-api:${project.fpa_version}")
 
-	modImplementation "io.github.ladysnake:PlayerAbilityLib:${project.pal_version}"
-}
+	modImplementation "io.github.ladysnake:PlayerAbilityLib:${pal_version}"
+	include "io.github.ladysnake:PlayerAbilityLib:${pal_version}"}
 
 processResources {
 	inputs.property "version", project.version

--- a/gradle.properties
+++ b/gradle.properties
@@ -3,19 +3,19 @@ org.gradle.jvmargs=-Xmx1G
 
 # Fabric Properties
 # check these on https://fabricmc.net/develop
-minecraft_version=1.19
-yarn_mappings=1.19+build.1
-loader_version=0.14.6
+minecraft_version=1.20.1
+yarn_mappings=1.20.1+build.10
+loader_version=0.14.24
 
 # Mod Properties
-mod_version = 1.0.4
+mod_version = 2.0.0
 maven_group = me.braunly
 archives_base_name = toggle-pvp
 
 # Dependencies
 # Fabric API
-fabric_version=0.55.1+1.19
+fabric_version=0.90.7+1.20.1
 # Fabric Permission API
-fpa_version = 0.2-SNAPSHOT
+fpa_version = 0.3-SNAPSHOT
 # PlayerAbilityLib
-pal_version = 1.6.0
+pal_version = 1.8.0

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.3.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/me/braunly/togglepvp/Perms.java
+++ b/src/main/java/me/braunly/togglepvp/Perms.java
@@ -1,9 +1,5 @@
 package me.braunly.togglepvp;
 
-import me.lucko.fabric.api.permissions.v0.PermissionCheckEvent;
-import net.fabricmc.fabric.api.util.TriState;
-import net.minecraft.command.CommandSource;
-
 public class Perms {
     public static final class Registry {
         // Access to /pvp command

--- a/src/main/resources/assets/togglepvp/lang/en_us.json
+++ b/src/main/resources/assets/togglepvp/lang/en_us.json
@@ -1,0 +1,8 @@
+{
+  "message.togglepvp.pvp_status": "PVP status ",
+  "message.togglepvp.pvp_status.other": "PVP status for ",
+  "message.togglepvp.pvp_state.enabled": "§cENABLED",
+  "message.togglepvp.pvp_state.disabled": "§aDISABLED",
+  "command.autocomplete.togglevpvp.enable": "on",
+  "command.autocomplete.togglevpvp.disable": "off"
+}

--- a/src/main/resources/assets/togglepvp/lang/es_es.json
+++ b/src/main/resources/assets/togglepvp/lang/es_es.json
@@ -1,0 +1,8 @@
+{
+  "message.togglepvp.pvp_status": "estado PVP",
+  "message.togglepvp.pvp_status.other": "Estado PVP para ",
+  "message.togglepvp.pvp_state.enabled": "ACTIVADO",
+  "message.togglepvp.pvp_state.disabled": "DESACTIVADO",
+  "command.autocomplete.togglevpvp.enable": "activado",
+  "command.autocomplete.togglevpvp.disable": "desactivado"
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -36,12 +36,12 @@
   "depends": {
     "fabricloader": ">=0.14.6",
     "fabric": "*",
-    "minecraft": "1.19.x",
+    "minecraft": "1.20.x",
     "java": ">=17",
     "fabric-permissions-api-v0": "*",
-    "playerabilitylib": ">=1.6.0"
+    "playerabilitylib": ">=1.8.0"
   },
   "suggests": {
-    "luckperms": ">=5.4.28"
+    "luckperms": ">=5.4.108"
   }
 }


### PR DESCRIPTION
 - Updated `minecraft_version` to `Minecraft 1.20.1`
 - Updated `yarn_mappings` to `1.20.1+build.10`
 - Updated `loader_version` to `0.14.24`
 - Updated `fabric_version` to `0.90.7+1.20.1`
 - Updated `fabric-loom` to `1.4-SNAPSHOT`
 - Updated Fabric Permissions API to `0.3-SNAPSHOT`
 - Updated Player Ability Lib to `1.8.0`
 - Updated Gradle to `8.3`
 - Updated Ladysnakes Mods Maven url
 - Added translation capability for command feedback text
 - Added translation capability for command input
   - e.g. `/pvp <PLAYER_NAME> activado` == `/pvp <PLAYER_NAME> enable`; Autocomplete for non-English input does not work yet
 - Added Spanish (Spain) Translation
 - Optimised Imports
 - The colours that are in the styling of the `PvpCommand` class don't do anything any more. They were left for reference so that people can know the the colours in the `lang` files are